### PR TITLE
Add ffmpeg regression tests

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -146,25 +146,3 @@ jobs:
         run: |
           export FFMPEG_BIN_PATH=ffmpeg-bin-ubuntu2204-${{ matrix.build_type }}
           ./tests/acceptance-test.sh
-
-  build-then-run-fate:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wangyoucao577/ffmpeg-build/linux-debian11
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-          submodules: 'true'
-          
-      - name: Build
-        run: |
-          export FFMPEG_ENABLE_FATE_TESTS=true
-          buildtools/scripts/build.sh
-          tree build
-
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: ffbuild-logs-fate
-          path: ffmpeg/ffbuild/config.log

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -1,0 +1,99 @@
+name: Regression tests
+on: 
+  push:
+    branches:
+      - '**'
+    tags:
+      - 'v*'
+    paths-ignore:
+      - 'buildtools/docker/**'
+      - 'docs/**'
+      - '.vscode/**'
+      - '.devcontainer/**'
+      - '**.md'
+
+jobs:
+  ffmpeg-fate:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wangyoucao577/ffmpeg-build/linux-debian11
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          submodules: 'true'
+          
+      - name: Build and run ffmpeg fate suites
+        run: |
+          export FFMPEG_ENABLE_FATE_TESTS=true
+          buildtools/scripts/build.sh
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ffbuild-logs-fate
+          path: ffmpeg/ffbuild/config.log
+
+  ffmpeg-coverage:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wangyoucao577/ffmpeg-build/linux-debian11
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          submodules: 'true'
+          
+      - name: Build with gcov and run ffmpeg fate suites
+        run: |
+          export FFMPEG_BUILD_TYPE=Debug
+          export FFMPEG_ENABLE_FATE_TESTS=true
+          export FFMPEG_TOOLCHAIN_COVERAGE=true
+          buildtools/scripts/build.sh
+
+      - name: Run acceptance tests
+        run: |
+          cp build/bin/vmaf*.json ffmpeg/
+          cd ffmpeg
+          export FFMPEG_BIN_PATH=.
+          ../tests/acceptance-test.sh
+
+      - name: Generate coverage report
+        run: |
+          cd ffmpeg
+          make lcov
+          ls -lh lcov/
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ffmpeg-coverage
+          path: ffmpeg/lcov/
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ffbuild-logs-coverage
+          path: ffmpeg/ffbuild/config.log
+
+  ffmpeg-valgrind-memcheck:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/wangyoucao577/ffmpeg-build/linux-debian11
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
+          submodules: 'true'
+          
+      - name: Build with gcov and run ffmpeg fate suites
+        run: |
+          export FFMPEG_BUILD_TYPE=Debug
+          export FFMPEG_ENABLE_FATE_TESTS=true
+          export FFMPEG_TOOLCHAIN_VALGRIND_MEMCHECK=true
+          buildtools/scripts/build.sh
+
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: ffbuild-logs-valgrind-memcheck
+          path: ffmpeg/ffbuild/config.log

--- a/.github/workflows/regression-tests.yml
+++ b/.github/workflows/regression-tests.yml
@@ -75,25 +75,25 @@ jobs:
           name: ffbuild-logs-coverage
           path: ffmpeg/ffbuild/config.log
 
-  ffmpeg-valgrind-memcheck:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wangyoucao577/ffmpeg-build/linux-debian11
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: '0'
-          submodules: 'true'
+  # ffmpeg-valgrind-memcheck:
+  #   runs-on: ubuntu-latest
+  #   container:
+  #     image: ghcr.io/wangyoucao577/ffmpeg-build/linux-debian11
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: '0'
+  #         submodules: 'true'
           
-      - name: Build with gcov and run ffmpeg fate suites
-        run: |
-          export FFMPEG_BUILD_TYPE=Debug
-          export FFMPEG_ENABLE_FATE_TESTS=true
-          export FFMPEG_TOOLCHAIN_VALGRIND_MEMCHECK=true
-          buildtools/scripts/build.sh
+  #     - name: Build with gcov and run ffmpeg fate suites
+  #       run: |
+  #         export FFMPEG_BUILD_TYPE=Debug
+  #         export FFMPEG_ENABLE_FATE_TESTS=true
+  #         export FFMPEG_TOOLCHAIN_VALGRIND_MEMCHECK=true
+  #         buildtools/scripts/build.sh
 
-      - uses: actions/upload-artifact@v3
-        if: failure()
-        with:
-          name: ffbuild-logs-valgrind-memcheck
-          path: ffmpeg/ffbuild/config.log
+  #     - uses: actions/upload-artifact@v3
+  #       if: failure()
+  #       with:
+  #         name: ffbuild-logs-valgrind-memcheck
+  #         path: ffmpeg/ffbuild/config.log

--- a/buildtools/docker/install-tools-debian.sh
+++ b/buildtools/docker/install-tools-debian.sh
@@ -42,3 +42,14 @@ wget --progress=dot:mega --no-check-certificate https://go.dev/dl/$(curl https:/
   stow -v -t ../bin bin && \
   cd ~ && \
   go version
+
+# install valgrind
+wget --progress=dot:mega --no-check-certificate https://sourceware.org/pub/valgrind/valgrind-3.20.0.tar.bz2 -O valgrind-3.20.0.tar.bz2 && \
+  tar -xjf valgrind-3.20.0.tar.bz2 && \
+  cd valgrind-3.20.0 && \
+  ./configure --enable-only64bit && \
+  make -j $(nproc) && make install && \
+  cd ../ && \
+  which valgrind && \
+  /usr/local/bin/valgrind --version && \
+  rm -rf ./valgrind*

--- a/buildtools/docker/install-tools-debian.sh
+++ b/buildtools/docker/install-tools-debian.sh
@@ -2,7 +2,7 @@
 
 # Install basic packages
 apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
-  build-essential pkg-config automake libtool python3-pip gperf \
+  build-essential pkg-config automake libtool python3-pip gperf lcov \
   yasm nasm libssl-dev \
   vim curl wget rsync git jq zip unzip tree stow \
   lsb-release software-properties-common gnupg2 autoconf \

--- a/buildtools/scripts/build-ffmpeg.sh
+++ b/buildtools/scripts/build-ffmpeg.sh
@@ -20,9 +20,16 @@ PROJECT_ROOT_PATH=${CURRENT_DIR_PATH}/../../
 
 source ${CURRENT_DIR_PATH}/options.sh
 
-# build type
+# build type, toolchain
 if [[ ${FFMPEG_BUILD_TYPE_INTERNAL} == "Debug" ]]; then
     FFMPEG_DEBUG_PARAMS=(--enable-debug=3 --disable-optimizations --disable-stripping --extra-cflags=-fno-omit-frame-pointer --extra-cflags=-fno-inline)
+fi
+FFMPEG_TOOLCHAIN_PARAMS=
+if [[ ${FFMPEG_TOOLCHAIN_VALGRIND_MEMCHECK} =~ "true" ]]; then
+    FFMPEG_TOOLCHAIN_PARAMS="--toolchain=valgrind-memcheck"
+fi
+if [[ ${FFMPEG_TOOLCHAIN_COVERAGE} =~ "true" ]]; then
+    FFMPEG_TOOLCHAIN_PARAMS="--toolchain=gcov"
 fi
 
 # whether enable nvidia gpu
@@ -70,7 +77,7 @@ set -x
   --enable-libfreetype --enable-libfontconfig --enable-libfribidi --enable-libass \
   --enable-sdl \
   --enable-libsrt \
-  ${FFMPEG_STATIC_SHARED_PARAMS} ${FFMPEG_PROGRAMS_STATIC_LINKING} \
+  ${FFMPEG_STATIC_SHARED_PARAMS} ${FFMPEG_PROGRAMS_STATIC_LINKING} ${FFMPEG_TOOLCHAIN_PARAMS} \
   "${FFMPEG_WITH_SSL_PARAMS[@]}" "${FFMPEG_WITH_NV_PARAMS[@]}" "${FFMPEG_DEBUG_PARAMS[@]}" "$@"
 make -i clean
 ${BEAR_COMMAND} make ${BEAR_MAKE_PARALLEL} build

--- a/docs/build.md
+++ b/docs/build.md
@@ -57,6 +57,8 @@ export FFMPEG_BUILD_TYPE=Debug
 | - | - | - | - |
 | `FFMPEG_BUILD_TYPE` | `Release`, `Debug` | `Release` | build type for ffmpeg | 
 | `FFMPEG_ENABLE_FATE_TESTS` | `true`, `false` | `false` | whether enable ffmpeg fate tests |
+| `FFMPEG_TOOLCHAIN_COVERAGE` | `true`, `false` | `false` | configure `ffmpeg` with `--toolchain=gcov`, see more in [9.2 Visualizing Test Coverage](https://ffmpeg.org/developer.html#Visualizing-Test-Coverage). |
+| `FFMPEG_TOOLCHAIN_VALGRIND_MEMCHECK` | `true`, `false` | `false` | configure `ffmpeg` with `--toolchain=valgrind-memcheck`, see more in [9.3 Using Valgrind](https://ffmpeg.org/developer.html#Using-Valgrind). |
 
 ## References
 - [CompilationGuide](https://trac.ffmpeg.org/wiki/CompilationGuide)

--- a/tests/acceptance-test.sh
+++ b/tests/acceptance-test.sh
@@ -28,6 +28,6 @@ ${FFMPEG_BIN_PATH}/ffmpeg -y -i ${TESTS_PATH}/out_264.mp4 -i ${TESTS_PATH}/small
 ${FFMPEG_BIN_PATH}/ffmpeg -y -threads 1 -i ${TESTS_PATH}/small_bunny_1080p_60fps.mp4 -c:v libx265 -c:a libfdk_aac ${TESTS_PATH}/out_hevc.mp4
 ${FFMPEG_BIN_PATH}/ffmpeg -y -i ${TESTS_PATH}/out_hevc.mp4 -c copy ${TESTS_PATH}/out_hevc.flv
 ${FFMPEG_BIN_PATH}/ffmpeg -y -i ${TESTS_PATH}/out_hevc.flv -c copy ${TESTS_PATH}/out_hevc2.mp4
-${FFMPEG_BIN_PATH}/ffmpeg -y -i ${TESTS_PATH}/small_bunny_1080p_60fps.mp4 -vf drawtext="text='hello world':fontfile=${FFMPEG_BIN_PATH}/FreeSans.ttf" -f null -
+${FFMPEG_BIN_PATH}/ffmpeg -y -i ${TESTS_PATH}/small_bunny_1080p_60fps.mp4 -vf drawtext="text='hello world':fontfile=${TESTS_PATH}/FreeSans.ttf" -f null -
 ${FFMPEG_BIN_PATH}/ffmpeg -y -i ${TESTS_PATH}/small_bunny_1080p_60fps.mp4 -vf subtitles=${TESTS_PATH}/sintel_en.srt -f null -
 ${FFMPEG_BIN_PATH}/ffmpeg -y -i ${TESTS_PATH}/small_bunny_1080p_60fps.mp4 -vn -af aresample=resampler=soxr -ar 8000 ${TESTS_PATH}/out.aac


### PR DESCRIPTION
- Install `valgrind` and `lcov`;     
- Add `FFMPEG_TOOLCHAIN_COVERAGE` and `FFMPEG_TOOLCHAIN_VALGRIND_MEMCHECK` options;      
- Add ffmpeg regression tests on CI, including run fate suites, coverage and valgrind memcheck;    
 