### PR TITLE
Remove cudnn and tensorrt to reduce cuda image size 

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     strategy:
       matrix:
-        image_name: [linux-ubuntu2204, linux-debian11, linux-debian10, linux-debian9, linux-android-sdk, linux-cuda]
+        image_name: [linux-ubuntu2204, linux-debian11, linux-debian10, linux-android-sdk, linux-cuda]
     runs-on: ubuntu-latest
     steps:
     - name: Checkout

--- a/buildtools/docker/install-tools-debian.sh
+++ b/buildtools/docker/install-tools-debian.sh
@@ -14,7 +14,7 @@ pip3 install meson && \
   meson --version
 
 # install conan
-pip3 install conan && \
+pip3 install conan==1.60 && \
   conan --version
 
 # install gcovr

--- a/buildtools/docker/install-tools-debian.sh
+++ b/buildtools/docker/install-tools-debian.sh
@@ -38,7 +38,7 @@ wget --progress=dot:mega https://github.com/ninja-build/ninja/releases/download/
   ninja --version
 
 # install go
-wget --progress=dot:mega --no-check-certificate https://go.dev/dl/$(curl https://go.dev/VERSION?m=text).linux-amd64.tar.gz -O go.linux-amd64.tar.gz && \
+wget --progress=dot:mega --no-check-certificate https://go.dev/dl/$(curl https://go.dev/VERSION?m=text | head -n1).linux-amd64.tar.gz -O go.linux-amd64.tar.gz && \
   tar -zxf go.linux-amd64.tar.gz && \
   mv go /usr/local/ && \
   rm -f go.linux-amd64.tar.gz && \

--- a/buildtools/docker/linux-cuda.dockerfile
+++ b/buildtools/docker/linux-cuda.dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.3.1-cudnn8-devel-ubuntu20.04
+FROM nvidia/cuda:11.3.1-devel-ubuntu20.04
 
 # nvidia-container-runtime envs, see https://github.com/NVIDIA/nvidia-container-runtime
 ENV NVIDIA_VISIBLE_DEVICES all
@@ -17,14 +17,14 @@ RUN /install-tools-debian.sh
 # tensorrt: https://docs.nvidia.com/deeplearning/tensorrt/install-guide/index.html#maclearn-net-repo-install
 # tensorrt: https://docs.nvidia.com/deeplearning/tensorrt/quick-start-guide/index.html#installing-debian
 # be aware that tensorrt 8.4.3.1-1+cuda11.6 compatible with cuda11.2
-RUN wget --progress=dot:mega --no-check-certificate https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
-  mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
-  apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub && \
-  add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" && \
-  apt-get update && \
-  apt-get install --no-install-recommends -y \
-    tensorrt-libs=8.5.2.2-1+cuda11.8 tensorrt-dev=8.5.2.2-1+cuda11.8 && \
-  rm -rf /var/lib/apt/lists/*
+# RUN wget --progress=dot:mega --no-check-certificate https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-ubuntu2004.pin && \
+#   mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600 && \
+#   apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub && \
+#   add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/ /" && \
+#   apt-get update && \
+#   apt-get install --no-install-recommends -y \
+#     tensorrt-libs=8.5.2.2-1+cuda11.8 tensorrt-dev=8.5.2.2-1+cuda11.8 && \
+#   rm -rf /var/lib/apt/lists/*
 
 # for shown on runtime
 ARG IMAGE_TAG

--- a/buildtools/docker/linux-cuda.dockerfile
+++ b/buildtools/docker/linux-cuda.dockerfile
@@ -35,3 +35,4 @@ RUN echo IMAGE_TAG=${IMAGE_TAG} >> /etc/environment
 LABEL maintainer="wangyoucao577@gmail.com"
 LABEL org.opencontainers.image.source https://github.com/wangyoucao577/ffmpeg-build
 
+


### PR DESCRIPTION
- remove cudnn and tensorrt to reduce cuda image size
- remove `linux-debian9` support
- lock conan 1.60 version